### PR TITLE
Improve default branch detection

### DIFF
--- a/check-variables.lua
+++ b/check-variables.lua
@@ -37,6 +37,10 @@ local function check_variables(repo, i)
         print("Error: `dir` is not set for repository " .. i)
         os.exit(1)
     end
+
+    if repo[i].def_branch == nil then
+        print("Warning: default branch not specified for `" .. repo[i].name .. "`. Attempting to obtain the default branch using the API.")
+    end
 end
 
 return {

--- a/repos-template.lua
+++ b/repos-template.lua
@@ -1,8 +1,10 @@
 local repos = {
     {
-        name = "",              -- Name of the module, used as directory name as well.
-        url = "",               -- URL link. Any VCS link (GitLab, GitHub, NotABug, etc.) should be used.
-        dir = "libs/"           -- Directory where the repository will be cloned. Always include `/` at the end.
+        name = "",            -- Name of the repository, used as directory name as well.
+        url = "",             -- URL link. Any VCS link (GitLab, GitHub, NotABug, etc.) should be used.
+        dir = "libs/",        -- Directory where the repository will be cloned. Always include `/` at the end.
+        def_branch = "main"   -- The default branch of the repository. If not specified, the script will try to
+                              -- find the default branch name. Currently supports GitHub, GitLab, and BitBucket.
     }
     -- Add any other repositories here.
 }

--- a/repos-test.lua
+++ b/repos-test.lua
@@ -15,6 +15,12 @@ local repos = {
         name = "cloud_items",
         url = "https://github.com/minetest-mods/cloud_items",
         dir = "libs/"
+    },
+    {
+        name = "mobs_redo",
+        url = "https://notabug.org/TenPlus1/mobs_redo",
+        dir = "libs/",
+        def_branch = "master"
     }
 }
 


### PR DESCRIPTION
Things added/changed:

- Improve default branch detection.
  - The default branch will be automatically fetched by using its API. **This is currently compatible only with GitHub, BitBucket, and GitLab.** Other VCS are not supported yet, due to the lack of accessible API or popularity.
  - If the default branch is manually provided, the script won't attempt to find the default branch for the given repository.
  - If the VCS is not supported and no default branch is provided, the script will skip the current repository and continue.