### PR TITLE
Major workflow bugfixes

### DIFF
--- a/.github/workflows/test-script.yml
+++ b/.github/workflows/test-script.yml
@@ -7,11 +7,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: Panquesito7/submodules-alternative@v1
+      - uses: Panquesito7/submodules-alternative@dev
         with:
           repos_filename: repos-test
           use_pr: true
           branch_name: submodule-update
           add_repos: true
           update_repos: true
-          squash_commits: true
+          squash_commits: false

--- a/action.yml
+++ b/action.yml
@@ -49,18 +49,19 @@ runs:
         else
           git checkout -b ${{ inputs.branch_name }}
         fi
-    - name: Update the repos file
+    - name: Update the repositories file
       shell: bash
       run: |
-        rm ${{ inputs.repos_filename }}.lua || true
+        if [[ $(git diff --name-only origin/${GITHUB_REF##*/} ${{ inputs.repos_filename }}) ]]; then
+          git rm ${{ inputs.repos_filename }}.lua || true
 
-        default_branch=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
-        wget https://raw.githubusercontent.com/${{ github.repository }}/${default_branch}/${{ inputs.repos_filename }}.lua
+          default_branch=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+          wget https://raw.githubusercontent.com/${{ github.repository }}/${default_branch}/${{ inputs.repos_filename }}.lua
 
-        # If the file is different, commit. If not, don't commit.
-        if [[ $(git diff --name-only) ]]; then
-          git add ${{ inputs.repos_filename }}.lua
-          git commit -m 'Update repos file'
+          if [[ $(git diff --name-only) ]]; then
+            git add ${{ inputs.repos_filename }}.lua
+            git commit -m 'Update repositories file'
+          fi
         fi
     - name: Setup Lua
       uses: xpol/setup-lua@master
@@ -70,43 +71,59 @@ runs:
       shell: bash
       run: |
         if [[ ${{ inputs.add_repos }} == true ]]; then
+          # Committing is necessary if we want to revert the changes and fetching
+          # the script at the same time, as otherwise, the script below would fail.
+          if [[ ! -f fetch-repos.lua ]]; then
+            wget https://raw.githubusercontent.com/Panquesito7/submodules-alternative/main/fetch-repos.lua
+            git add fetch-repos.lua
+            git commit -m "Get the fetch-repos script"
+          fi
+
           lua fetch-repos.lua ${{ inputs.repos_filename }}
         fi
     - name: Update repositories
       shell: bash
       run: |
         if [[ ${{ inputs.update_repos }} == true ]]; then
+          if [[ ! -f update-repos.lua ]]; then
+            wget https://raw.githubusercontent.com/Panquesito7/submodules-alternative/main/update-repos.lua
+          fi
           lua update-repos.lua ${{ inputs.repos_filename }}
         fi
     - name: Push changes and create PR
       shell: bash
       run: |
-        count=$(git log --branches --not --remotes --oneline | wc -l)
-        count=$((count / 2)) # Divide by 2 because each repository addition contains 2 commits.
+        if [[ ${{ inputs.add_repos }} == true ]]; then
+          count=$(git log --branches --not --remotes --oneline | wc -l)
+          count=$((count / 2)) # Divide by 2 because each repository addition contains 2 commits.
 
-        if [[ $(gh pr list --state open --base ${GITHUB_REF##*/} --head ${{ inputs.branch_name }} | wc -l) -gt 0 ]]; then
-          count=$((count + 1))
-        fi
+          if [[ $(gh pr list --state open --base ${GITHUB_REF##*/} --head ${{ inputs.branch_name }} | wc -l) -gt 0 ]]; then
+            count=$((count + 1))
+          fi
 
-        if [[ $(git diff --name-only) ]]; then
-          count=$((count + 1))
-        fi
+          if [[ $(git diff --name-only) ]]; then
+            count=$((count + 1))
+          fi
 
-        if [[ ${{ inputs.use_pr }} == true ]]; then
           if [[ $(git log --branches --not --remotes) ]] && [[ ${{ inputs.squash_commits }} == true ]]; then
             git reset --soft HEAD~$count
             git commit -m '${{ inputs.commit_message }}'
           fi
+        fi
 
-          git push origin ${{ inputs.branch_name }}:${{ inputs.branch_name }}
+        if [[ ${{ inputs.update_repos }} == true ]]; then
+          git add -A -- ':!fetch-repos.lua' ':!update-repos.lua'
+          git commit -m '${{ inputs.commit_message }}' || true
+        fi
+
+        # Removes the `fetch-repos.lua` script from the repository, as it is not needed.
+        git revert $(git log --branches --not --remotes --grep 'Get the fetch-repos script' --oneline | cut -d' ' -f1) --no-edit || true
+
+        if [[ ${{ inputs.use_pr }} == true ]]; then
+          git push origin ${{ inputs.branch_name }}:${{ inputs.branch_name }} || true
           gh pr create --base ${GITHUB_REF##*/} --head ${{ inputs.branch_name }} --title '${{ inputs.commit_message }}' --body 'Repositories were added or updated using the Submodules Alternative tool.' || true
         else
-            if [[ $(git log --branches --not --remotes) ]] && [[ ${{ inputs.squash_commits }} == true ]]; then
-              git reset --soft HEAD~$count
-              git commit -m '${{ inputs.commit_message }}'
-            fi
-
-            git push
+          git push || true
         fi
       env:
         GH_TOKEN: ${{ github.token }}

--- a/update-repos.lua
+++ b/update-repos.lua
@@ -30,9 +30,17 @@ local function update_repos()
         -- Make sure all of the variables are set.
         check_variables(repos, i)
 
+        -- Make sure the repository is cloned already.
+        if os.execute("test -d " .. repos[i].dir .. repos[i].name) ~= 0 then
+            print("Warning: " .. repos[i].dir .. repos[i].name .. " does not exist. Skipping.")
+            goto continue
+        end
+
         -- Update the repository with the given options.
         os.execute("cd " .. repos[i].dir .. repos[i].name .. " && git pull")
         os.execute("cd ..") -- Go back
+
+        ::continue::
     end
 end
 


### PR DESCRIPTION
Things added/changed:

- Major workflow bugfixes.
  - The script wasn't able to run the scripts on external repositories due to the lack of the scripts. The script now fetches the scripts if not available in the given repository. Closes #28.
  - Both the `fetch-repos` and `update-repos` scripts should work properly by using the GitHub action. Previously, it was messy and not working properly.
  - If the squash commits option is enabled, the script will _attempt_ to squash all the repositories being added by `fetch-repos`. **This feature is still experimental and may be removed in the future to prevent history from being lost.**
  - At the moment of updating the repositories, if the given directory/repository is not available, it will skip and continue with the next one. If nothing is available, the script will exit normally.

This was fully tested in [various runs](https://github.com/Panquesito7/submodules-alternative/actions/workflows/test-script.yml) and on #29.
